### PR TITLE
Remove Type from type name

### DIFF
--- a/packages/generator/src/type/index.js
+++ b/packages/generator/src/type/index.js
@@ -50,7 +50,7 @@ class TypeGenerator extends Base {
 
     const destinationPath = this.destinationPath(`${this.destinationDir}/${typeFileName}.js`);
     const templateVars = {
-      name: typeFileName,
+      name,
       schema,
     };
 


### PR DESCRIPTION
example:
name: 'LikeType' will be only name: 'Like' on GraphQLObjectType

fix #13