### PR TITLE
Improve Mutation & Loader templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,5 @@
     "prepublish": "npm run build",
     "test": "jest --runInBand --config jest.json",
     "watch": "lerna exec -- npm run watch"
-  },
-  "dependencies": {
-    "pluralize": "^3.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,5 +35,8 @@
     "prepublish": "npm run build",
     "test": "jest --runInBand --config jest.json",
     "watch": "lerna exec -- npm run watch"
+  },
+  "dependencies": {
+    "pluralize": "^3.1.0"
   }
 }

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -19,7 +19,8 @@
     "recast": "^0.11.17",
     "semver": "^5.1.0",
     "shelljs": "^0.7.4",
-    "yeoman-generator": "^0.24.1"
+    "yeoman-generator": "^0.24.1",
+    "pluralize": "^3.1.0"
   },
   "devDependencies": {},
   "files": [

--- a/packages/generator/src/loader/__tests__/__snapshots__/LoaderGenerator.spec.js.snap
+++ b/packages/generator/src/loader/__tests__/__snapshots__/LoaderGenerator.spec.js.snap
@@ -38,7 +38,7 @@ export default class Example {
   }
 
   static async load(viewer, id) {
-    const data = await Example.ExampleLoader.load(id);
+    const data = await Example.ExampleLoader.load(id.toString());
 
     return Example.viewerCanSee(viewer, data) ? new Example(data) : null;
   }
@@ -47,16 +47,14 @@ export default class Example {
     return Example.ExampleLoader.clear(id.toString());
   }
 
-  static async loadExample(viewer, args) {
-    // TODO: load multiple rows
-
-    const Example = [];
+  static async loadExamples(viewer, args) {
+    // TODO: specify conditions
+    const examples = ExampleModel.find({});
 
     return ConnectionFromMongoCursor.connectionFromMongoCursor(
-      viewer, Example, args, Example.load,
+      viewer, examples, args, Example.load,
     );
   }
-
 }
 ",
 }
@@ -108,7 +106,7 @@ export default class Post {
   }
 
   static async load(viewer, id) {
-    const data = await Post.PostLoader.load(id);
+    const data = await Post.PostLoader.load(id.toString());
 
     return Post.viewerCanSee(viewer, data) ? new Post(data) : null;
   }
@@ -117,16 +115,14 @@ export default class Post {
     return Post.PostLoader.clear(id.toString());
   }
 
-  static async loadPosts(viewer, args) {
-    // TODO: load multiple rows
-
-    const Post = [];
+  static async loadPostss(viewer, args) {
+    // TODO: specify conditions
+    const posts = PostModel.find({});
 
     return ConnectionFromMongoCursor.connectionFromMongoCursor(
-      viewer, Post, args, Post.load,
+      viewer, posts, args, Post.load,
     );
   }
-
 }
 ",
 }

--- a/packages/generator/src/loader/index.js
+++ b/packages/generator/src/loader/index.js
@@ -1,8 +1,10 @@
 import { Base } from 'yeoman-generator';
+import pluralize from 'pluralize';
 import {
   getMongooseModelSchema,
   getConfigDir,
   getRelativeConfigDir,
+  camelCaseText,
   uppercaseFirstLetter,
 } from '../utils';
 
@@ -40,10 +42,14 @@ class LoaderGenerator extends Base {
 
     const directories = this._getConfigDirectories();
 
+    const pluralName = pluralize(this.name);
+
     const destinationPath = this.destinationPath(`${this.destinationDir}/${name}Loader.js`);
     const templateVars = {
       name,
       rawName: this.name,
+      pluralName,
+      pluralCamelCaseName: camelCaseText(pluralName),
       schema,
       directories,
     };

--- a/packages/generator/src/loader/templates/Loader.js.template
+++ b/packages/generator/src/loader/templates/Loader.js.template
@@ -36,7 +36,7 @@ export default class <%= name %> {
   }
 
   static async load(viewer, id) {
-    const data = await <%= name %>.<%= rawName %>Loader.load(id);
+    const data = await <%= name %>.<%= rawName %>Loader.load(id.toString());
 
     return <%= name %>.viewerCanSee(viewer, data) ? new <%= name %>(data) : null;
   }
@@ -45,14 +45,12 @@ export default class <%= name %> {
     return <%= name %>.<%= rawName %>Loader.clear(id.toString());
   }
 
-  static async load<%= name %>(viewer, args) {
-    // TODO: load multiple rows
-
-    const <%= rawName %> = [];
+  static async load<%= pluralName %>(viewer, args) {
+    // TODO: specify conditions
+    const <%= pluralCamelCaseName %> = <%= name %>Model.find({});
 
     return ConnectionFromMongoCursor.connectionFromMongoCursor(
-      viewer, <%= rawName %>, args, <%= name %>.load,
+      viewer, <%= pluralCamelCaseName %>, args, <%= name %>.load,
     );
   }
-
 }

--- a/packages/generator/src/loader/templates/LoaderWithSchema.js.template
+++ b/packages/generator/src/loader/templates/LoaderWithSchema.js.template
@@ -42,7 +42,7 @@ export default class <%= name %> {
   }
 
   static async load(viewer, id) {
-    const data = await <%= name %>.<%= rawName %>Loader.load(id);
+    const data = await <%= name %>.<%= rawName %>Loader.load(id.toString());
 
     return <%= name %>.viewerCanSee(viewer, data) ? new <%= name %>(data) : null;
   }
@@ -51,14 +51,12 @@ export default class <%= name %> {
     return <%= name %>.<%= rawName %>Loader.clear(id.toString());
   }
 
-  static async load<%= name %>s(viewer, args) {
-    // TODO: load multiple rows
-
-    const <%= rawName %> = [];
+  static async load<%= pluralName %>s(viewer, args) {
+    // TODO: specify conditions
+    const <%= pluralCamelCaseName %> = <%= name %>Model.find({});
 
     return ConnectionFromMongoCursor.connectionFromMongoCursor(
-      viewer, <%= rawName %>, args, <%= name %>.load,
+      viewer, <%= pluralCamelCaseName %>, args, <%= name %>.load,
     );
   }
-
 }

--- a/packages/generator/src/mutation/__tests__/__snapshots__/MutationGenerator.spec.js.snap
+++ b/packages/generator/src/mutation/__tests__/__snapshots__/MutationGenerator.spec.js.snap
@@ -40,9 +40,8 @@ export default mutationWithClientMutationId({
   outputFields: {
     exampleEdge: {
       type: ExampleConnection.edgeType,
-      resolve: async({ id }, args, { user }) => {
-        // TODO: load new edge from loader
-
+      resolve: async ({ id }, args, { user }) => {
+        // Load new edge from loader
         const example = await ExampleLoader.load(
           user, id,
         );
@@ -53,7 +52,7 @@ export default mutationWithClientMutationId({
         }
 
         return {
-          cursor: toGlobalId(\'example\', example),
+          cursor: toGlobalId(\'Example\', example),
           node: example,
         };
       },
@@ -303,11 +302,10 @@ export default mutationWithClientMutationId({
   outputFields: {
     postEdge: {
       type: PostConnection.edgeType,
-      resolve: async({ id }, args, { user }) => {
-        // TODO: load new edge from loader
-
+      resolve: async ({ id }, args, { user }) => {
+        // Load new edge from loader
         const post = await PostLoader.load(
-          user, id
+          user, id,
         );
 
         // Returns null if no node was loaded
@@ -316,7 +314,7 @@ export default mutationWithClientMutationId({
         }
 
         return {
-          cursor: toGlobalId(\'post\', post),
+          cursor: toGlobalId(\'Post\', post),
           node: post,
         };
       },

--- a/packages/generator/src/mutation/templates/MutationAdd.js.template
+++ b/packages/generator/src/mutation/templates/MutationAdd.js.template
@@ -38,9 +38,8 @@ export default mutationWithClientMutationId({
   outputFields: {
     <%= camelCaseName %>Edge: {
       type: <%= name %>Connection.edgeType,
-      resolve: async({ id }, args, { user }) => {
-        // TODO: load new edge from loader
-
+      resolve: async ({ id }, args, { user }) => {
+        // Load new edge from loader
         const <%= camelCaseName %> = await <%= name %>Loader.load(
           user, id,
         );
@@ -51,7 +50,7 @@ export default mutationWithClientMutationId({
         }
 
         return {
-          cursor: toGlobalId('<%= camelCaseName %>', <%= camelCaseName %>),
+          cursor: toGlobalId('<%= name %>', <%= camelCaseName %>),
           node: <%= camelCaseName %>,
         };
       },

--- a/packages/generator/src/mutation/templates/MutationAddWithSchema.js.template
+++ b/packages/generator/src/mutation/templates/MutationAddWithSchema.js.template
@@ -47,11 +47,10 @@ export default mutationWithClientMutationId({
   outputFields: {
     <%= camelCaseName %>Edge: {
       type: <%= name %>Connection.edgeType,
-      resolve: async({ id }, args, { user }) => {
-        // TODO: load new edge from loader
-
+      resolve: async ({ id }, args, { user }) => {
+        // Load new edge from loader
         const <%= camelCaseName %> = await <%= name %>Loader.load(
-          user, id
+          user, id,
         );
 
         // Returns null if no node was loaded
@@ -60,7 +59,7 @@ export default mutationWithClientMutationId({
         }
 
         return {
-          cursor: toGlobalId('<%= camelCaseName %>', <%= camelCaseName %>),
+          cursor: toGlobalId('<%= name %>', <%= camelCaseName %>),
           node: <%= camelCaseName %>,
         };
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3274,6 +3274,10 @@ pluralize@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-1.2.1.tgz#d1a21483fd22bb41e58a12fa3421823140897c45"
 
+pluralize@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-3.1.0.tgz#84213d0a12356069daa84060c559242633161368"
+
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"


### PR DESCRIPTION
- [x] Fix ESLint issues in Mutation templates & Use raw name instead of camelCased to register the `GlobalID`;
- [x] Assure that the ID passed to Loader's `load` function is always string;
- [x] Add _pre-ready_  `loadAllRows` function to load all rows in the collection;
- [x] Improve the naming of functions by using a pluralization package.