### PR TITLE
Add AppVeyor for Windows testing and improve Travis CI

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+coverage

--- a/.eslintrc
+++ b/.eslintrc
@@ -8,7 +8,8 @@
     "no-continue": 0,
     "no-underscore-dangle": 0,
     "generator-star-spacing": 0,
-    "class-methods-use-this": 0
+    "class-methods-use-this": 0,
+    "import/no-extraneous-dependencies": 0 // https://github.com/benmosher/eslint-plugin-import/pull/685
   },
   "env": {
     "jest": true

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,11 @@ before_install:
 
 install:
   - yarn
-  - npm run bootstrap
+  - yarn bootstrap
 
 script:
-  - npm run lint
-  - npm run test
+  - yarn lint
+  - yarn test -- --runInBand
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,16 @@ before_install:
   - export PATH=$HOME/.yarn/bin:$PATH
 
 install:
-  - yarn
-  - yarn bootstrap
+  - yarn install
+  - yarn run bootstrap
 
 script:
-  - yarn lint
-  - yarn test -- --runInBand
+  - node --version
+  - npm --version
+  - yarn --version
+  - ./node_modules/.bin/eslint --version
+  - yarn run lint
+  - yarn run test -- --runInBand
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 </p>
 <p align="center">
   <a href="https://travis-ci.org/lucasbento/create-graphql"><img src="https://travis-ci.org/lucasbento/create-graphql.svg?branch=master"></a>
+  <a href="https://ci.appveyor.com/project/lucasbento/create-graphql/branch/master"><img src="https://ci.appveyor.com/api/projects/status/cpxul2ofnyf6ypy8/branch/master?svg=true"></a>
   <a href="https://codecov.io/gh/lucasbento/create-graphql"><img src="https://img.shields.io/codecov/c/github/lucasbento/create-graphql.svg"></a>
   <a href="https://github.com/airbnb/javascript"><img src="https://img.shields.io/badge/code%20style-airbnb-blue.svg"></a>
   <a href="https://github.com/lucasbento/create-graphql/issues"><img src="https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat"></a>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,12 +8,12 @@ install:
   - ps: Install-Product node $env:node_version
   - npm install -g npm@3.x
   - yarn install
-  - yarn run bootstrap
+  - npm run bootstrap
 
 build: off
 
 test_script:
   - node --version
   - yarn --version
-  - yarn run lint
-  - yarn run test -- --runInBand
+  - npm run lint
+  - npm run test -- --runInBand

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,15 +3,18 @@ environment:
     - node_version: "6"
     - node_version: "4"
 
-cache:
-  - "%LOCALAPPDATA%\\Yarn"
-
 install:
   - ps: Install-Product node $env:nodejs_version
   - yarn install
+
+build: off
 
 test_script:
   - node --version
   - yarn --version
   - yarn lint
   - yarn test -- --runInBand
+
+cache:
+  - node_modules
+  - "%LOCALAPPDATA%\\Yarn"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,9 +6,6 @@ environment:
 
 install:
   - ps: Install-Product node $env:node_version
-  - npm cache clean
-  - npm install -g npm@3.x
-  - set PATH=%APPDATA%\npm;%PATH%
   - yarn install
   - yarn run bootstrap
 
@@ -16,7 +13,6 @@ build: off
 
 test_script:
   - node --version
-  - npm --version
   - yarn --version
   - yarn run lint
   - yarn run test -- --runInBand

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,10 +5,10 @@ environment:
 
 install:
   - ps: Install-Product node $env:node_version
-  - npm install -g npm@3.x
+  - npm install -g npm@2.x
   - set PATH=%APPDATA%\npm;%PATH%
-  - yarn install
-  - yarn run bootstrap
+  - npm install
+  - npm run bootstrap
 
 build: off
 
@@ -17,8 +17,8 @@ test_script:
   - npm --version
   - yarn --version
   - ./node_modules/.bin/eslint --version
-  - yarn run lint
-  - yarn run test -- --runInBand
+  - npm run lint
+  - npm run test -- --runInBand
 
 cache:
   - "%LOCALAPPDATA%\\Yarn"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ environment:
 install:
   - ps: Install-Product node $env:nodejs_version
   - yarn install
+  - yarn bootstrap
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ environment:
 install:
   - ps: Install-Product node $env:nodejs_version
   - yarn global add npm@3.x
+  - set PATH=%APPDATA%\npm;%PATH%
   - npm cache clean
   - yarn install
   - yarn run bootstrap

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ environment:
 
 install:
   - ps: Install-Product node $env:node_version
+  - npm cache clean
   - npm install -g npm@2.x
   - set PATH=%APPDATA%\npm;%PATH%
   - yarn install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,5 +18,4 @@ test_script:
   - yarn test -- --runInBand
 
 cache:
-  - node_modules
   - "%LOCALAPPDATA%\\Yarn"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ test_script:
   - node --version
   - npm --version
   - yarn --version
-  - eslint --version
+  - ./node_modules/.bin/eslint --version
   - yarn run lint
   - yarn run test -- --runInBand
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
 
 install:
   - ps: Install-Product node $env:node_version
-  - yarn global add npm@3.x
+  - npm install -g npm@3.x
   - set PATH=%APPDATA%\npm;%PATH%
   - yarn install
   - yarn run bootstrap

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ environment:
 
 install:
   - ps: Install-Product node $env:nodejs_version
+  - npm install -g npm@3.x
   - yarn install
   - yarn bootstrap
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ environment:
 install:
   - ps: Install-Product node $env:node_version
   - npm install -g npm@3.x
-  - yarn install
+  - npm install
   - npm run bootstrap
 
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,7 @@ test_script:
   - node --version
   - npm --version
   - yarn --version
+  - eslint --version
   - yarn run lint
   - yarn run test -- --runInBand
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,7 @@
 environment:
-  nodejs_version: "6"
-  nodejs_version: "4"
+  matrix:
+    - node_version: "6"
+    - node_version: "4"
 
 cache:
   - "%LOCALAPPDATA%\\Yarn"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,16 @@
+environment:
+  nodejs_version: "6"
+  nodejs_version: "4"
+
+cache:
+  - "%LOCALAPPDATA%\\Yarn"
+
+install:
+  - ps: Install-Product node $env:nodejs_version
+  - yarn install
+
+test_script:
+  - node --version
+  - yarn --version
+  - yarn lint
+  - yarn test -- --runInBand

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ environment:
 install:
   - ps: Install-Product node $env:node_version
   - npm cache clean
-  - npm install -g npm@2.x
+  - npm install -g npm@3.x
   - set PATH=%APPDATA%\npm;%PATH%
   - yarn install
   - yarn run bootstrap

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,14 +1,15 @@
 environment:
   matrix:
-    - node_version: "6"
     - node_version: "4"
+    - node_version: "6"
+    - node_version: "7"
 
 install:
   - ps: Install-Product node $env:node_version
   - npm install -g npm@2.x
   - set PATH=%APPDATA%\npm;%PATH%
-  - npm install
-  - npm run bootstrap
+  - yarn install
+  - yarn run bootstrap
 
 build: off
 
@@ -16,9 +17,8 @@ test_script:
   - node --version
   - npm --version
   - yarn --version
-  - ./node_modules/.bin/eslint --version
-  - npm run lint
-  - npm run test -- --runInBand
+  - yarn run lint
+  - yarn run test -- --runInBand
 
 cache:
   - "%LOCALAPPDATA%\\Yarn"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,7 @@ build: off
 
 test_script:
   - node --version
+  - npm --version
   - yarn --version
   - yarn lint
   - yarn test -- --runInBand

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,10 +4,9 @@ environment:
     - node_version: "4"
 
 install:
-  - ps: Install-Product node $env:nodejs_version
+  - ps: Install-Product node $env:node_version
   - yarn global add npm@3.x
   - set PATH=%APPDATA%\npm;%PATH%
-  - npm cache clean
   - yarn install
   - yarn run bootstrap
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,6 +19,3 @@ test_script:
   - yarn --version
   - yarn run lint
   - yarn run test -- --runInBand
-
-cache:
-  - "%LOCALAPPDATA%\\Yarn"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ environment:
 
 install:
   - ps: Install-Product node $env:node_version
+  - yarn cache clean
   - yarn install
   - yarn run bootstrap
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,9 +5,10 @@ environment:
 
 install:
   - ps: Install-Product node $env:nodejs_version
-  - npm install -g npm@3.x
+  - yarn global add npm@3.x
+  - npm cache clean
   - yarn install
-  - yarn bootstrap
+  - yarn run bootstrap
 
 build: off
 
@@ -15,8 +16,8 @@ test_script:
   - node --version
   - npm --version
   - yarn --version
-  - yarn lint
-  - yarn test -- --runInBand
+  - yarn run lint
+  - yarn run test -- --runInBand
 
 cache:
   - "%LOCALAPPDATA%\\Yarn"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ environment:
 
 install:
   - ps: Install-Product node $env:node_version
-  - yarn cache clean
+  - npm install -g npm@3.x
   - yarn install
   - yarn run bootstrap
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "bootstrap": "lerna bootstrap",
     "build": "lerna exec -- npm run build",
     "clean": "lerna clean",
-    "lint": "eslint packages/*/src/**/*.js packages/*/__tests__ ",
+    "lint": "./node_modules/.bin/eslint packages/*/src/**/*.js packages/*/__tests__ ",
     "prepublish": "npm run build",
     "test": "jest --config jest.json",
     "watch": "lerna exec -- npm run watch"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "bootstrap": "lerna bootstrap",
     "build": "lerna exec -- npm run build",
     "clean": "lerna clean",
-    "lint": "./node_modules/.bin/eslint packages/*/src/**/*.js packages/*/__tests__ ",
+    "lint": "eslint packages/*/src/**/*.js packages/*/__tests__ ",
     "prepublish": "npm run build",
     "test": "jest --config jest.json",
     "watch": "lerna exec -- npm run watch"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "clean": "lerna clean",
     "lint": "eslint packages/*/src/**/*.js packages/*/__tests__ ",
     "prepublish": "npm run build",
-    "test": "jest --runInBand --config jest.json",
+    "test": "jest --config jest.json",
     "watch": "lerna exec -- npm run watch"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "bootstrap": "lerna bootstrap",
     "build": "lerna exec -- npm run build",
     "clean": "lerna clean",
-    "lint": "eslint packages/*/src/**/*.js packages/*/__tests__ ",
+    "lint": "eslint \"packages/*/src/**/*.js\" \"packages/*/__tests__\"",
     "prepublish": "npm run build",
     "test": "jest --config jest.json",
     "watch": "lerna exec -- npm run watch"

--- a/packages/generator/src/connection/__tests__/ConnectionGenerator.spec.js
+++ b/packages/generator/src/connection/__tests__/ConnectionGenerator.spec.js
@@ -63,6 +63,6 @@ it('should always import connectionDefinitions', async () => {
   const connectionFile = `${destinationDir}/ExampleConnection.js`;
 
   assert.fileContent(
-    connectionFile, 'import { connectionDefinitions } from \'graphql-relay\';'
+    connectionFile, 'import { connectionDefinitions } from \'graphql-relay\';',
   );
 });

--- a/packages/generator/src/utils.js
+++ b/packages/generator/src/utils.js
@@ -8,6 +8,13 @@ const { visit } = recast.types;
 
 const rootPath = pkgDir.sync('.') || '.';
 
+/**
+ * Uppercase the first letter of a text
+ * @param text {string}
+ * @returns {string}
+ */
+export const uppercaseFirstLetter = text => `${text.charAt(0).toUpperCase()}${text.slice(1)}`;
+
 const parseFieldToGraphQL = (field, ref) => {
   const graphQLField = {
     name: field.name,
@@ -45,13 +52,13 @@ const parseFieldToGraphQL = (field, ref) => {
           graphqlType: typeFileName,
           graphqlLoader: loaderFileName,
         };
-      } else {
-        return {
-          ...graphQLField,
-          type: 'GraphQLID',
-          flowType: 'string',
-        }
       }
+
+      return {
+        ...graphQLField,
+        type: 'GraphQLID',
+        flowType: 'string',
+      };
     case 'Date':
       return {
         ...graphQLField,
@@ -84,11 +91,8 @@ const parseGraphQLSchema = (mongooseFields, ref) => {
       if (loaderDependencies.indexOf(field.graphqlLoader) === -1) {
         loaderDependencies.push(field.graphqlLoader);
       }
-
-    } else {
-      if (dependencies.indexOf(field.type) === -1) {
-        dependencies.push(field.type);
-      }
+    } else if (dependencies.indexOf(field.type) === -1) {
+      dependencies.push(field.type);
     }
 
     return field;
@@ -100,39 +104,6 @@ const parseGraphQLSchema = (mongooseFields, ref) => {
     typeDependencies,
     loaderDependencies,
   };
-};
-
-const getSchemaFieldsFromAst = (node, withTimestamps) => {
-  const astSchemaFields = node.arguments[0].properties;
-
-  const fields = [];
-  astSchemaFields.forEach((field) => {
-    const name = field.key.name;
-
-    const fieldDefinition = {};
-
-    if (field.value.type === 'ArrayExpression') {
-      return;
-    }
-
-    field.value.properties.forEach(({ key, value }) => fieldDefinition[key.name] = value.name || value.value);
-
-    fields[name] = {
-      name,
-      ...fieldDefinition,
-    };
-  });
-
-  if (withTimestamps) {
-    const astSchemaTimestamp = getSchemaTimestampsFromAst(node.arguments[1].properties);
-
-    return {
-      ...fields,
-      ...astSchemaTimestamp,
-    };
-  }
-
-  return fields;
 };
 
 /**
@@ -153,17 +124,52 @@ const getSchemaTimestampsFromAst = (nodes) => {
           name: fieldName,
           type: 'Date',
         };
-      })
+      });
     }
   });
 
   return timestampFields;
 };
 
+const getSchemaFieldsFromAst = (node, withTimestamps) => {
+  const astSchemaFields = node.arguments[0].properties;
+
+  const fields = [];
+  astSchemaFields.forEach((field) => {
+    const name = field.key.name;
+
+    const fieldDefinition = {};
+
+    if (field.value.type === 'ArrayExpression') {
+      return;
+    }
+
+    field.value.properties.forEach(({ key, value }) => {
+      fieldDefinition[key.name] = value.name || value.value;
+    });
+
+    fields[name] = {
+      name,
+      ...fieldDefinition,
+    };
+  });
+
+  if (withTimestamps) {
+    const astSchemaTimestamp = getSchemaTimestampsFromAst(node.arguments[1].properties);
+
+    return {
+      ...fields,
+      ...astSchemaTimestamp,
+    };
+  }
+
+  return fields;
+};
+
 const getSchemaDefinition = (modelCode, withTimestamps, ref) => {
   const ast = recast.parse(modelCode, {
     parser: {
-      parse: source => require('babylon').parse(source, {
+      parse: source => require('babylon').parse(source, { // eslint-disable-line global-require
         sourceType: 'module',
         plugins: [
           'asyncFunctions',
@@ -240,7 +246,7 @@ export const getCreateGraphQLConfig = () => {
   // Use default config
   const defaultFilePath = path.resolve(`${__dirname}/graphqlrc.json`);
 
-  let config = parseConfigFile(defaultFilePath);
+  const config = parseConfigFile(defaultFilePath);
 
   try {
     // Check if there is a `.graphqlrc` file in the root path
@@ -262,7 +268,7 @@ export const getCreateGraphQLConfig = () => {
  * @param directory {string} The name of the directory, e.g. 'source'/'mutation'
  * @returns {string} The directory path
  */
-export const getConfigDir = (directory) => getCreateGraphQLConfig().directories[directory];
+export const getConfigDir = directory => getCreateGraphQLConfig().directories[directory];
 
 /**
  * Get the relative path directory between two directories specified on the config file
@@ -283,10 +289,17 @@ export const getRelativeConfigDir = (from, to) => {
   }, {});
 };
 
+/**
+ * Get the Mongoose model schema code
+ * @param modelPath {string} The path of the Mongoose model
+ * @returns {string} The code of the Mongoose model
+ */
+const getModelCode = modelPath => fs.readFileSync(modelPath, 'utf8');
+
 export const getMongooseModelSchema = ({
   model,
   withTimestamps = false,
-  ref = false
+  ref = false,
 }) => {
   const modelDir = getCreateGraphQLConfig().directories.model;
 
@@ -298,30 +311,15 @@ export const getMongooseModelSchema = ({
 };
 
 /**
- * Get the Mongoose model schema code
- * @param modelPath {string} The path of the Mongoose model
- * @returns {string} The code of the Mongoose model
- */
-const getModelCode = modelPath => fs.readFileSync(modelPath, 'utf8');
-
-/**
  * Camel cases text
  * @param text {string} Text to be camel-cased
  * @returns {string} Camel-cased text
  */
-export const camelCaseText = (text) => {
-  return text.replace(/(?:^\w|[A-Z]|\b\w|\s+)/g, (match, index) => {
+export const camelCaseText = text =>
+  text.replace(/(?:^\w|[A-Z]|\b\w|\s+)/g, (match, index) => {
     if (+match === 0) {
       return '';
     }
 
     return index === 0 ? match.toLowerCase() : match.toUpperCase();
   });
-};
-
-/**
- * Uppercase the first letter of a text
- * @param text {string}
- * @returns {string}
- */
-export const uppercaseFirstLetter = text => `${text.charAt(0).toUpperCase()}${text.slice(1)}`;


### PR DESCRIPTION
This PR introduces Windows support (🍾), removes the need for `--runInBand` option on Jest (which is to run tests sequentially) and keeps it only on the CI's.

With this PR, I also found a bug on the way we use ESLint, on Windows it caught more errors than in Linux/OSX, it was because of the way they parse globs (don't ask me why the hell it happens, simply thank @ilyavolodin).

There are a bunch of commits here, let's squash and merge them.

---

cc @felippepuhle.

Fixes #67.