### PR TITLE
Correctly retrieve type when declared directly

### DIFF
--- a/packages/generator/fixtures/User.js
+++ b/packages/generator/fixtures/User.js
@@ -19,6 +19,7 @@ const Schema = new mongoose.Schema({
     type: Boolean,
     default: true,
   },
+  lastLoginAt: Date,
 }, {
   collection: 'user',
 });

--- a/packages/generator/src/loader/__tests__/__snapshots__/LoaderGenerator.spec.js.snap
+++ b/packages/generator/src/loader/__tests__/__snapshots__/LoaderGenerator.spec.js.snap
@@ -150,6 +150,7 @@ type UserType = {
   password: string,
   email: string,
   active: boolean,
+  lastLoginAt: string,
 }
 
 export default class User {
@@ -159,6 +160,7 @@ export default class User {
   password: string;
   email: string;
   active: boolean;
+  lastLoginAt: string;
 
   static getLoader = () => new DataLoader(ids => mongooseLoader(UserModel, ids));
 
@@ -169,6 +171,7 @@ export default class User {
     this.password = data.password;
     this.email = data.email;
     this.active = data.active;
+    this.lastLoginAt = data.lastLoginAt;
   }
 
   static viewerCanSee(viewer, data) {

--- a/packages/generator/src/type/__tests__/__snapshots__/TypeGenerator.spec.js.snap
+++ b/packages/generator/src/type/__tests__/__snapshots__/TypeGenerator.spec.js.snap
@@ -184,6 +184,11 @@ export default new GraphQLObjectType({
       description: '',
       resolve: obj => obj.active,
     },
+    lastLoginAt: {
+      type: GraphQLString,
+      description: '',
+      resolve: obj => obj.lastLoginAt.toISOString(),
+    },
   }),
   interfaces: () => [NodeInterface],
 });

--- a/packages/generator/src/utils.js
+++ b/packages/generator/src/utils.js
@@ -135,6 +135,10 @@ const getSchemaFieldsFromAst = (node, withTimestamps) => {
   const astSchemaFields = node.arguments[0].properties;
 
   const fields = [];
+  // MemberExpression: { field1: Schema.Types.ObjectId }
+  // Identifier: { field1: ObjectId }
+  const validSingleValueTypes = ['MemberExpression', 'Identifier'];
+
   astSchemaFields.forEach((field) => {
     const name = field.key.name;
 
@@ -142,11 +146,13 @@ const getSchemaFieldsFromAst = (node, withTimestamps) => {
 
     if (field.value.type === 'ArrayExpression') {
       return;
+    } else if (validSingleValueTypes.indexOf(field.value.type) !== -1) {
+      fieldDefinition.type = field.value.property ? field.value.property.name : field.value.name;
+    } else {
+      field.value.properties.forEach(({ key, value }) => {
+        fieldDefinition[key.name] = value.name || value.value;
+      });
     }
-
-    field.value.properties.forEach(({ key, value }) => {
-      fieldDefinition[key.name] = value.name || value.value;
-    });
 
     fields[name] = {
       name,


### PR DESCRIPTION
You can declare the type of mongoose fields directly, without using an object, like `{ field: String }` or `{ field: Schema.Types.ObjectId }`.

Fixes #87 

https://runkit.com/jcmais/5900b3565581b700125e1ab5