### PR TITLE
Fix templates to match latest version of graphql-dataloader-boilerplate

### DIFF
--- a/packages/generator/src/loader/__tests__/__snapshots__/LoaderGenerator.spec.js.snap
+++ b/packages/generator/src/loader/__tests__/__snapshots__/LoaderGenerator.spec.js.snap
@@ -34,26 +34,26 @@ export default class Example {
     return true;
   }
 
-  static async load(viewer, id) {
+  static async load({ user: viewer, dataloaders }, id) {
     if (!id) {
       return null;
     }
 
-    const data = await Example.ExampleLoader.load(id.toString());
+    const data = await dataloaders.ExampleLoader.load(id.toString());
 
     return Example.viewerCanSee(viewer, data) ? new Example(data) : null;
   }
 
-  static clearCache(id) {
-    return Example.ExampleLoader.clear(id.toString());
+  static clearCache({ dataloaders }, id) {
+    return dataloaders.ExampleLoader.clear(id.toString());
   }
 
-  static async loadExamples(viewer, args) {
+  static async loadExamples(context, args) {
     // TODO: specify conditions
     const examples = ExampleModel.find({});
 
     return ConnectionFromMongoCursor.connectionFromMongoCursor(
-      viewer, examples, args, Example.load,
+      context, examples, args, Example.load,
     );
   }
 }
@@ -107,26 +107,26 @@ export default class Post {
     return true;
   }
 
-  static async load(viewer, id) {
+  static async load({ user: viewer, dataloaders }, id) {
     if (!id) {
       return null;
     }
 
-    const data = await Post.PostLoader.load(id.toString());
+    const data = await dataloaders.PostLoader.load(id.toString());
 
     return Post.viewerCanSee(viewer, data) ? new Post(data) : null;
   }
 
-  static clearCache(id) {
-    return Post.PostLoader.clear(id.toString());
+  static clearCache({ dataloaders }, id) {
+    return dataloaders.PostLoader.clear(id.toString());
   }
 
-  static async loadPosts(viewer, args) {
+  static async loadPosts(context, args) {
     // TODO: specify conditions
     const posts = PostModel.find({});
 
     return ConnectionFromMongoCursor.connectionFromMongoCursor(
-      viewer, posts, args, Post.load,
+      context, posts, args, Post.load,
     );
   }
 }
@@ -180,26 +180,26 @@ export default class User {
     return true;
   }
 
-  static async load(viewer, id) {
+  static async load({ user: viewer, dataloaders }, id) {
     if (!id) {
       return null;
     }
 
-    const data = await User.UserLoader.load(id.toString());
+    const data = await dataloaders.UserLoader.load(id.toString());
 
     return User.viewerCanSee(viewer, data) ? new User(data) : null;
   }
 
-  static clearCache(id) {
-    return User.UserLoader.clear(id.toString());
+  static clearCache({ dataloaders }, id) {
+    return dataloaders.UserLoader.clear(id.toString());
   }
 
-  static async loadUsers(viewer, args) {
+  static async loadUsers(context, args) {
     // TODO: specify conditions
     const users = UserModel.find({});
 
     return ConnectionFromMongoCursor.connectionFromMongoCursor(
-      viewer, users, args, User.load,
+      context, users, args, User.load,
     );
   }
 }

--- a/packages/generator/src/loader/templates/Loader.js.template
+++ b/packages/generator/src/loader/templates/Loader.js.template
@@ -30,26 +30,26 @@ export default class <%= name %> {
     return true;
   }
 
-  static async load(viewer, id) {
+  static async load({ user: viewer, dataloaders }, id) {
     if (!id) {
       return null;
     }
 
-    const data = await <%= name %>.<%= rawName %>Loader.load(id.toString());
+    const data = await dataloaders.<%= rawName %>Loader.load(id.toString());
 
     return <%= name %>.viewerCanSee(viewer, data) ? new <%= name %>(data) : null;
   }
 
-  static clearCache(id) {
-    return <%= name %>.<%= rawName %>Loader.clear(id.toString());
+  static clearCache({ dataloaders }, id) {
+    return dataloaders.<%= rawName %>Loader.clear(id.toString());
   }
 
-  static async load<%= pluralName %>(viewer, args) {
+  static async load<%= pluralName %>(context, args) {
     // TODO: specify conditions
     const <%= pluralCamelCaseName %> = <%= name %>Model.find({});
 
     return ConnectionFromMongoCursor.connectionFromMongoCursor(
-      viewer, <%= pluralCamelCaseName %>, args, <%= name %>.load,
+      context, <%= pluralCamelCaseName %>, args, <%= name %>.load,
     );
   }
 }

--- a/packages/generator/src/loader/templates/LoaderWithSchema.js.template
+++ b/packages/generator/src/loader/templates/LoaderWithSchema.js.template
@@ -36,26 +36,26 @@ export default class <%= name %> {
     return true;
   }
 
-  static async load(viewer, id) {
+  static async load({ user: viewer, dataloaders }, id) {
     if (!id) {
       return null;
     }
 
-    const data = await <%= name %>.<%= rawName %>Loader.load(id.toString());
+    const data = await dataloaders.<%= rawName %>Loader.load(id.toString());
 
     return <%= name %>.viewerCanSee(viewer, data) ? new <%= name %>(data) : null;
   }
 
-  static clearCache(id) {
-    return <%= name %>.<%= rawName %>Loader.clear(id.toString());
+  static clearCache({ dataloaders }, id) {
+    return dataloaders.<%= rawName %>Loader.clear(id.toString());
   }
 
-  static async load<%= pluralName %>(viewer, args) {
+  static async load<%= pluralName %>(context, args) {
     // TODO: specify conditions
     const <%= pluralCamelCaseName %> = <%= name %>Model.find({});
 
     return ConnectionFromMongoCursor.connectionFromMongoCursor(
-      viewer, <%= pluralCamelCaseName %>, args, <%= name %>.load,
+      context, <%= pluralCamelCaseName %>, args, <%= name %>.load,
     );
   }
 }

--- a/packages/generator/src/mutation/__tests__/__snapshots__/MutationGenerator.spec.js.snap
+++ b/packages/generator/src/mutation/__tests__/__snapshots__/MutationGenerator.spec.js.snap
@@ -42,10 +42,10 @@ export default mutationWithClientMutationId({
   outputFields: {
     exampleEdge: {
       type: ExampleConnection.edgeType,
-      resolve: async ({ id }, args, { user }) => {
+      resolve: async ({ id }, args, context) => {
         // Load new edge from loader
         const example = await ExampleLoader.load(
-          user, id,
+          context, id,
         );
 
         // Returns null if no node was loaded
@@ -68,7 +68,7 @@ export default mutationWithClientMutationId({
 ",
   "addTest": "import { graphql } from 'graphql';
 import { schema } from '../../schema';
-import { setupTest } from '../../../test/helper';
+import { setupTest, getContext } from '../../../test/helper';
 
 import User from '../model/User';
 import Example from '../model/Example';
@@ -88,7 +88,7 @@ it('should not allow anonymous user', async () => {
 
   const rootValue = {};
   // No user should be passed to context since we are testing an anonymous session
-  const context = {};
+  const context = getContext();
 
   const result = await graphql(schema, query, rootValue, context);
 
@@ -114,7 +114,7 @@ it('should create a record on database', async () => {
   \`;
 
   const rootValue = {};
-  const context = { user };
+  const context = getContext({ user });
 
   const result = await graphql(schema, query, rootValue, context);
 
@@ -148,7 +148,9 @@ export default mutationWithClientMutationId({
       type: GraphQLString,
     },
   },
-  mutateAndGetPayload: async (args, { user }) => {
+  mutateAndGetPayload: async (args, context) => {
+    const { user } = context;
+
     // Verify if user is authorized
     if (!user) {
       throw new Error('Unauthorized user');
@@ -172,7 +174,7 @@ export default mutationWithClientMutationId({
     // TODO: mutation logic
 
     // Clear dataloader cache
-    ExampleLoader.clearCache(example._id);
+    ExampleLoader.clearCache(context, example._id);
 
     return {
       id: example._id,
@@ -182,7 +184,7 @@ export default mutationWithClientMutationId({
   outputFields: {
     example: {
       type: ExampleType,
-      resolve: (obj, args, { user }) => ExampleLoader.load(user, obj.id),
+      resolve: (obj, args, context) => ExampleLoader.load(context, obj.id),
     },
     error: {
       type: GraphQLString,
@@ -194,7 +196,7 @@ export default mutationWithClientMutationId({
   "editTest": "import { graphql } from 'graphql';
 import { toGlobalId } from 'graphql-relay';
 import { schema } from '../../schema';
-import { setupTest } from '../../../test/helper';
+import { setupTest, getContext } from '../../../test/helper';
 
 import User from '../model/User';
 import Example from '../model/Example';
@@ -215,7 +217,7 @@ it('should not allow anonymous user', async () => {
 
   const rootValue = {};
   // No user should be passed to context since we are testing an anonymous session
-  const context = {};
+  const context = getContext();
 
   const result = await graphql(schema, query, rootValue, context);
 
@@ -242,7 +244,7 @@ it('should create a record on database', async () => {
   \`;
 
   const rootValue = {};
-  const context = { user };
+  const context = getContext({ user });
 
   const result = await graphql(schema, query, rootValue, context);
 
@@ -315,10 +317,10 @@ export default mutationWithClientMutationId({
   outputFields: {
     postEdge: {
       type: PostConnection.edgeType,
-      resolve: async ({ id }, args, { user }) => {
+      resolve: async ({ id }, args, context) => {
         // Load new edge from loader
         const post = await PostLoader.load(
-          user, id,
+          context, id,
         );
 
         // Returns null if no node was loaded
@@ -345,7 +347,7 @@ export default mutationWithClientMutationId({
 ",
   "addTest": "import { graphql } from 'graphql';
 import { schema } from '../../schema';
-import { setupTest } from '../../../test/helper';
+import { setupTest, getContext } from '../../../test/helper';
 
 import User from '../model/User';
 import Post from '../model/Post';
@@ -373,7 +375,7 @@ it('should not allow anonymous user', async () => {
 
   const rootValue = {};
   // No user should be passed to context since we are testing an anonymous session
-  const context = {};
+  const context = getContext();
 
   const result = await graphql(schema, query, rootValue, context);
 
@@ -407,7 +409,7 @@ it('should create a record on database', async () => {
   \`;
 
   const rootValue = {};
-  const context = { user };
+  const context = getContext({ user });
 
   const result = await graphql(schema, query, rootValue, context);
 
@@ -447,7 +449,9 @@ export default mutationWithClientMutationId({
       type: GraphQLString,
     },
   },
-  mutateAndGetPayload: async (args, { user }) => {
+  mutateAndGetPayload: async (args, context) => {
+    const { user } = context;
+
     // Verify if user is authorized
     if (!user) {
       throw new Error('Unauthorized user');
@@ -480,7 +484,7 @@ export default mutationWithClientMutationId({
     // TODO: mutation logic
 
     // Clear dataloader cache
-    PostLoader.clearCache(post._id);
+    PostLoader.clearCache(context, post._id);
 
     return {
       id: post._id,
@@ -490,7 +494,7 @@ export default mutationWithClientMutationId({
   outputFields: {
     post: {
       type: PostType,
-      resolve: (obj, args, { user }) => PostLoader.load(user, obj.id),
+      resolve: (obj, args, context) => PostLoader.load(context, obj.id),
     },
     error: {
       type: GraphQLString,
@@ -502,7 +506,7 @@ export default mutationWithClientMutationId({
   "editTest": "import { graphql } from 'graphql';
 import { toGlobalId } from 'graphql-relay';
 import { schema } from '../../schema';
-import { setupTest } from '../../../test/helper';
+import { setupTest, getContext } from '../../../test/helper';
 
 import User from '../model/User';
 import Post from '../model/Post';
@@ -538,7 +542,7 @@ it('should not allow anonymous user', async () => {
 
   const rootValue = {};
   // No user should be passed to context since we are testing an anonymous session
-  const context = {};
+  const context = getContext();
 
   const result = await graphql(schema, query, rootValue, context);
 
@@ -580,7 +584,7 @@ it('should edit a record on database', async () => {
   \`;
 
   const rootValue = {};
-  const context = { user };
+  const context = getContext({ user });
 
   const result = await graphql(schema, query, rootValue, context);
 

--- a/packages/generator/src/mutation/templates/MutationAdd.js.template
+++ b/packages/generator/src/mutation/templates/MutationAdd.js.template
@@ -38,10 +38,10 @@ export default mutationWithClientMutationId({
   outputFields: {
     <%= camelCaseName %>Edge: {
       type: <%= name %>Connection.edgeType,
-      resolve: async ({ id }, args, { user }) => {
+      resolve: async ({ id }, args, context) => {
         // Load new edge from loader
         const <%= camelCaseName %> = await <%= name %>Loader.load(
-          user, id,
+          context, id,
         );
 
         // Returns null if no node was loaded

--- a/packages/generator/src/mutation/templates/MutationAddWithSchema.js.template
+++ b/packages/generator/src/mutation/templates/MutationAddWithSchema.js.template
@@ -56,10 +56,10 @@ export default mutationWithClientMutationId({
   outputFields: {
     <%= camelCaseName %>Edge: {
       type: <%= name %>Connection.edgeType,
-      resolve: async ({ id }, args, { user }) => {
+      resolve: async ({ id }, args, context) => {
         // Load new edge from loader
         const <%= camelCaseName %> = await <%= name %>Loader.load(
-          user, id,
+          context, id,
         );
 
         // Returns null if no node was loaded

--- a/packages/generator/src/mutation/templates/MutationEdit.js.template
+++ b/packages/generator/src/mutation/templates/MutationEdit.js.template
@@ -25,7 +25,9 @@ export default mutationWithClientMutationId({
       type: GraphQLString,
     },
   },
-  mutateAndGetPayload: async (args, { user }) => {
+  mutateAndGetPayload: async (args, context) => {
+    const { user } = context;
+
     // Verify if user is authorized
     if (!user) {
       throw new Error('Unauthorized user');
@@ -49,7 +51,7 @@ export default mutationWithClientMutationId({
     // TODO: mutation logic
 
     // Clear dataloader cache
-    <%= name %>Loader.clearCache(<%= camelCaseName %>._id);
+    <%= name %>Loader.clearCache(context, <%= camelCaseName %>._id);
 
     return {
       id: <%= camelCaseName %>._id,
@@ -59,7 +61,7 @@ export default mutationWithClientMutationId({
   outputFields: {
     <%= camelCaseName %>: {
       type: <%= name %>Type,
-      resolve: (obj, args, { user }) => <%= name %>Loader.load(user, obj.id),
+      resolve: (obj, args, context) => <%= name %>Loader.load(context, obj.id),
     },
     error: {
       type: GraphQLString,

--- a/packages/generator/src/mutation/templates/MutationEditWithSchema.js.template
+++ b/packages/generator/src/mutation/templates/MutationEditWithSchema.js.template
@@ -30,7 +30,9 @@ export default mutationWithClientMutationId({
     },
     <%_ } -%>
   },
-  mutateAndGetPayload: async (args, { user }) => {
+  mutateAndGetPayload: async (args, context) => {
+    const { user } = context;
+
     // Verify if user is authorized
     if (!user) {
       throw new Error('Unauthorized user');
@@ -63,7 +65,7 @@ export default mutationWithClientMutationId({
     // TODO: mutation logic
 
     // Clear dataloader cache
-    <%= name %>Loader.clearCache(<%= camelCaseName %>._id);
+    <%= name %>Loader.clearCache(context, <%= camelCaseName %>._id);
 
     return {
       id: <%= camelCaseName %>._id,
@@ -73,7 +75,7 @@ export default mutationWithClientMutationId({
   outputFields: {
     <%= camelCaseName %>: {
       type: <%= name %>Type,
-      resolve: (obj, args, { user }) => <%= name %>Loader.load(user, obj.id),
+      resolve: (obj, args, context) => <%= name %>Loader.load(context, obj.id),
     },
     error: {
       type: GraphQLString,

--- a/packages/generator/src/mutation/templates/test/MutationAdd.js.template
+++ b/packages/generator/src/mutation/templates/test/MutationAdd.js.template
@@ -1,6 +1,6 @@
 import { graphql } from 'graphql';
 import { schema } from '../../schema';
-import { setupTest } from '../../../test/helper';
+import { setupTest, getContext } from '../../../test/helper';
 
 import User from '<%= directories.model %>/User';
 import <%= name %> from '<%= directories.model %>/<%= name %>';
@@ -20,7 +20,7 @@ it('should not allow anonymous user', async () => {
 
   const rootValue = {};
   // No user should be passed to context since we are testing an anonymous session
-  const context = {};
+  const context = getContext();
 
   const result = await graphql(schema, query, rootValue, context);
 
@@ -46,7 +46,7 @@ it('should create a record on database', async () => {
   `;
 
   const rootValue = {};
-  const context = { user };
+  const context = getContext({ user });
 
   const result = await graphql(schema, query, rootValue, context);
 

--- a/packages/generator/src/mutation/templates/test/MutationAddWithSchema.js.template
+++ b/packages/generator/src/mutation/templates/test/MutationAddWithSchema.js.template
@@ -1,6 +1,6 @@
 import { graphql } from 'graphql';
 import { schema } from '../../schema';
-import { setupTest } from '../../../test/helper';
+import { setupTest, getContext } from '../../../test/helper';
 
 import User from '<%= directories.model %>/User';
 import <%= name %> from '<%= directories.model %>/<%= name %>';
@@ -28,7 +28,7 @@ it('should not allow anonymous user', async () => {
 
   const rootValue = {};
   // No user should be passed to context since we are testing an anonymous session
-  const context = {};
+  const context = getContext();
 
   const result = await graphql(schema, query, rootValue, context);
 
@@ -62,7 +62,7 @@ it('should create a record on database', async () => {
   `;
 
   const rootValue = {};
-  const context = { user };
+  const context = getContext({ user });
 
   const result = await graphql(schema, query, rootValue, context);
 

--- a/packages/generator/src/mutation/templates/test/MutationEdit.js.template
+++ b/packages/generator/src/mutation/templates/test/MutationEdit.js.template
@@ -1,7 +1,7 @@
 import { graphql } from 'graphql';
 import { toGlobalId } from 'graphql-relay';
 import { schema } from '../../schema';
-import { setupTest } from '../../../test/helper';
+import { setupTest, getContext } from '../../../test/helper';
 
 import User from '<%= directories.model %>/User';
 import <%= name %> from '<%= directories.model %>/<%= name %>';
@@ -22,7 +22,7 @@ it('should not allow anonymous user', async () => {
 
   const rootValue = {};
   // No user should be passed to context since we are testing an anonymous session
-  const context = {};
+  const context = getContext();
 
   const result = await graphql(schema, query, rootValue, context);
 
@@ -49,7 +49,7 @@ it('should create a record on database', async () => {
   `;
 
   const rootValue = {};
-  const context = { user };
+  const context = getContext({ user });
 
   const result = await graphql(schema, query, rootValue, context);
 

--- a/packages/generator/src/mutation/templates/test/MutationEditWithSchema.js.template
+++ b/packages/generator/src/mutation/templates/test/MutationEditWithSchema.js.template
@@ -1,7 +1,7 @@
 import { graphql } from 'graphql';
 import { toGlobalId } from 'graphql-relay';
 import { schema } from '../../schema';
-import { setupTest } from '../../../test/helper';
+import { setupTest, getContext } from '../../../test/helper';
 
 import User from '<%= directories.model %>/User';
 import <%= name %> from '<%= directories.model %>/<%= name %>';
@@ -37,7 +37,7 @@ it('should not allow anonymous user', async () => {
 
   const rootValue = {};
   // No user should be passed to context since we are testing an anonymous session
-  const context = {};
+  const context = getContext();
 
   const result = await graphql(schema, query, rootValue, context);
 
@@ -79,7 +79,7 @@ it('should edit a record on database', async () => {
   `;
 
   const rootValue = {};
-  const context = { user };
+  const context = getContext({ user });
 
   const result = await graphql(schema, query, rootValue, context);
 

--- a/packages/generator/src/type/__tests__/__snapshots__/TypeGenerator.spec.js.snap
+++ b/packages/generator/src/type/__tests__/__snapshots__/TypeGenerator.spec.js.snap
@@ -26,7 +26,7 @@ export default new GraphQLObjectType({
 ",
   "typeTest": "import { graphql } from 'graphql';
 import { schema } from '../../schema';
-import { setupTest } from '../../../../test/helper';
+import { setupTest, getContext } from '../../../../test/helper';
 import {
   User,
   Example,
@@ -50,7 +50,7 @@ it('should retrieve a record', async () => {
   \`;
 
   const rootValue = {};
-  const context = { user };
+  const context = getContext({ user });
 
   const { errors, data } = await graphql(schema, query, rootValue, context);
 
@@ -88,7 +88,7 @@ export default new GraphQLObjectType({
     user: {
       type: UserType,
       description: 'User that created this post',
-      resolve: async (obj, args, { user }) => await UserLoader.load(user, obj.user),
+      resolve: async (obj, args, context) => await UserLoader.load(context, obj.user),
     },
     slug: {
       type: GraphQLString,
@@ -111,7 +111,7 @@ export default new GraphQLObjectType({
 ",
   "typeTest": "import { graphql } from 'graphql';
 import { schema } from '../../schema';
-import { setupTest } from '../../../../test/helper';
+import { setupTest, getContext } from '../../../../test/helper';
 import {
   User,
   Post,
@@ -135,7 +135,7 @@ it('should retrieve a record', async () => {
   \`;
 
   const rootValue = {};
-  const context = { user };
+  const context = getContext({ user });
 
   const { errors, data } = await graphql(schema, query, rootValue, context);
 
@@ -195,7 +195,7 @@ export default new GraphQLObjectType({
 ",
   "typeTest": "import { graphql } from 'graphql';
 import { schema } from '../../schema';
-import { setupTest } from '../../../../test/helper';
+import { setupTest, getContext } from '../../../../test/helper';
 import {
   User,
   User,
@@ -219,7 +219,7 @@ it('should retrieve a record', async () => {
   \`;
 
   const rootValue = {};
-  const context = { user };
+  const context = getContext({ user });
 
   const { errors, data } = await graphql(schema, query, rootValue, context);
 

--- a/packages/generator/src/type/templates/test/Type.js.template
+++ b/packages/generator/src/type/templates/test/Type.js.template
@@ -1,6 +1,6 @@
 import { graphql } from 'graphql';
 import { schema } from '../../schema';
-import { setupTest } from '../../../../test/helper';
+import { setupTest, getContext } from '../../../../test/helper';
 import {
   User,
   <%= name %>,
@@ -24,7 +24,7 @@ it('should retrieve a record', async () => {
   `;
 
   const rootValue = {};
-  const context = { user };
+  const context = getContext({ user });
 
   const { errors, data } = await graphql(schema, query, rootValue, context);
 

--- a/packages/generator/src/utils.js
+++ b/packages/generator/src/utils.js
@@ -47,8 +47,8 @@ const parseFieldToGraphQL = (field, ref) => {
           ...graphQLField,
           type: typeFileName,
           flowType: 'string',
-          resolve: `await ${loaderFileName}.load(user, obj.${field.name})`,
-          resolveArgs: 'async (obj, args, { user })',
+          resolve: `await ${loaderFileName}.load(context, obj.${field.name})`,
+          resolveArgs: 'async (obj, args, context)',
           graphqlType: typeFileName,
           graphqlLoader: loaderFileName,
         };


### PR DESCRIPTION
This updates all generators to pass the `context` around, instead of just the current logged in user.

Note: This **will** break all projects currently using this package.